### PR TITLE
[CAN-28] Bugfix: Mobile Nav Overlay bug

### DIFF
--- a/app/ui/Footer/footer.tsx
+++ b/app/ui/Footer/footer.tsx
@@ -19,6 +19,7 @@ const footerStyle: React.CSSProperties = {
 
 const Footer: React.FC = () => {
     const currentYear = new Date().getFullYear();
+    const localActive = useLocale();
     return (
         <div style={footerStyle}>
             <div className='text-center py-4'>

--- a/app/ui/Navigation/overlaynav.tsx
+++ b/app/ui/Navigation/overlaynav.tsx
@@ -1,9 +1,12 @@
+'use client';
+
 import Link from 'next/link';
 import LinkInfo from '@/app/ui/Navigation/linkinfo';
 import Logo from '@/app/ui/Navigation/logo';
 import Close from '@/app/ui/Navigation/close';
 import LocalSwitcher from './translation-switch';
-import { EventHandler } from 'react';
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
 
 export default function OverlayNav({
     handleClick,
@@ -12,6 +15,14 @@ export default function OverlayNav({
     handleClick: Function;
     links: Array<LinkInfo>;
 }) {
+    const pathName = usePathname();
+
+    useEffect(() => {
+        () => {
+            handleClick();
+        };
+    }, [pathName]);
+
     return (
         <div
             onClick={(e) => {
@@ -35,6 +46,15 @@ export default function OverlayNav({
                     {links.map((link: LinkInfo) => {
                         return (
                             <Link
+                                onClick={
+                                    (pathName as string).includes(
+                                        link.href as string
+                                    )
+                                        ? () => {
+                                              handleClick();
+                                          }
+                                        : () => {}
+                                }
                                 className='min-w-full py-2'
                                 key={link.name}
                                 href={link.href}


### PR DESCRIPTION
Problem
When clicking on mobile Nav, overlay stays
Solution
- UseEffect handler for when router finally changes link 
- Match current URL and if clicked on, close overlay Note