### PR TITLE
[CAN-69] Hotifxes path that sitemaps are written to

### DIFF
--- a/generate-sitemap.mjs
+++ b/generate-sitemap.mjs
@@ -67,7 +67,7 @@ async function generate() {
             parser: 'html',
         });
 
-        writeFileSync(path.join('', `sitemap-${lang}.xml`), formatted); // Use path.join to construct file path
+        writeFileSync(path.join('out', `sitemap-${lang}.xml`), formatted); // Use path.join to construct file path
     }
 
     // generate sitemap index file here
@@ -91,7 +91,7 @@ async function generate() {
         parser: 'html',
     });
 
-    writeFileSync(path.join('', `sitemap.xml`), formatted);
+    writeFileSync(path.join('out', `sitemap.xml`), formatted);
 
 }
 


### PR DESCRIPTION
Problem
The next-sitemap packages writes to the out/ directory Solution
Trying the same with the customised sitemap generator script Note