### PR TITLE
[CAN-69] Hotfixes undefined namespace for xhmls:xhtml

### DIFF
--- a/generate-sitemap.mjs
+++ b/generate-sitemap.mjs
@@ -29,7 +29,7 @@ async function generate() {
 
         let sitemap = `
                 <?xml version="1.0" encoding="UTF-8"?>
-                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml/">
                     <url>
                         <loc>${siteUrl}</loc>
                         <xhtml:link


### PR DESCRIPTION
Problem
Namespace prefix xhtml on link is not defined
Solution
Solutions inspired by:
https://webmasters.stackexchange.com/questions/140804/sitemap-parsing-error and involves declaring xmlns:xhtml in the urlset tag Note