### PR TITLE
[CAN-69] Hotfixes all localized links to be self referencing

### DIFF
--- a/generate-sitemap.mjs
+++ b/generate-sitemap.mjs
@@ -36,6 +36,10 @@ async function generate() {
                rel="alternate"
                hreflang="${otherLanguage}"
                href="${alternativeSiteUrl}"/>
+               <xhtml:link
+               rel="alternate"
+               hreflang="${lang}"
+               href="${siteUrl}"/>
                         <lastmod>${new Date().toISOString()}</lastmod>
                     </url>
                 `;
@@ -51,6 +55,10 @@ async function generate() {
                rel="alternate"
                hreflang="${otherLanguage}"
                href="${alternativeSiteUrl}${route}"/>
+               <xhtml:link
+               rel="alternate"
+               hreflang="${lang}"
+               href="${siteUrl}${route}"/>
                         <lastmod>${new Date().toISOString()}</lastmod>                  
                     </url>
                     `;


### PR DESCRIPTION
Problem
After testing on https://technicalseo.com/tools/hreflang/, all of our hreflang tags were missing a self reference, which meant that the language for each link wasnt correctly identified
Solution
Add the appropriate hreflang rel to the sitemap generation script Note