### PR TITLE
[CAN-69] Hotfixes namespace issue for urlset

### DIFF
--- a/generate-sitemap.mjs
+++ b/generate-sitemap.mjs
@@ -29,7 +29,10 @@ async function generate() {
 
         let sitemap = `
                 <?xml version="1.0" encoding="UTF-8"?>
-                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml/">
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="https://www.w3.org/1999/xhtml/" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+                http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd
+                http://www.w3.org/1999/xhtml
+                http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd">
                     <url>
                         <loc>${siteUrl}</loc>
                         <xhtml:link


### PR DESCRIPTION
Problem
Your Sitemap or Sitemap index file doesn't properly declare the namespace. Parent Tag: url and Tag: link
Solution
Using:
https://webmasters.stackexchange.com/questions/128497/your-sitemap-or-sitemap-index-file-does-not-properly-declare-the-namespace I have added the appropriate namespace declarations to urlset Note