### PR TITLE
[CAN-69] Hotfixes incorrect https to http in sitemap namespace

### DIFF
--- a/generate-sitemap.mjs
+++ b/generate-sitemap.mjs
@@ -29,10 +29,7 @@ async function generate() {
 
         let sitemap = `
                 <?xml version="1.0" encoding="UTF-8"?>
-                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="https://www.w3.org/1999/xhtml/" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-                http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd
-                http://www.w3.org/1999/xhtml
-                http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd">
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
                     <url>
                         <loc>${siteUrl}</loc>
                         <xhtml:link


### PR DESCRIPTION
Problem
Google doesnt like https
Solution
THANK YOU INTERNET FOR THIS SOLUTION:
https://support.google.com/webmasters/thread/186962247/sitemap-can-be-read-but-has-errors-incorrect-namespace?hl=en Note