### PR TITLE
[CAN-69] Attempts to fix formatting on deploy's sitemaps

### DIFF
--- a/generate-sitemap.mjs
+++ b/generate-sitemap.mjs
@@ -29,7 +29,13 @@ async function generate() {
 
         let sitemap = `
                 <?xml version="1.0" encoding="UTF-8"?>
-                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+                http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd
+                http://www.w3.org/1999/xhtml
+                http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd">
                     <url>
                         <loc>${siteUrl}</loc>
                         <xhtml:link


### PR DESCRIPTION
Problem
Formatting doesnt exist on the external sitemaps
Solution
Attempting to roll back to a previous version where namespace fix exists however the formatting is different
Note