### PR TITLE
[HOTFIX] Replaces map tiler on individual club pages

### DIFF
--- a/app/components/OpenStreetMap/ClubOpenStreetMap.tsx
+++ b/app/components/OpenStreetMap/ClubOpenStreetMap.tsx
@@ -40,7 +40,7 @@ export default function ClubOpenStreetMap({ club }: ClubProps) {
         >
             <TileLayer
                 //url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                url="https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png"
+                url="https://api.maptiler.com/maps/toner-v2/{z}/{x}/{y}.png?key=KFzeqoMZOcvot9qqW4I8"
                 attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             />
 


### PR DESCRIPTION
In ClubOpenStreetMap, the old map tiler was still being used. @marcaufderheyde correctly pointed out that this needed to be changed.